### PR TITLE
Update esphome-ensto.yaml

### DIFF
--- a/config/esphome-ensto.yaml
+++ b/config/esphome-ensto.yaml
@@ -131,6 +131,7 @@ binary_sensor:
 sensor:
 # Real-time information (temperatures, is heating relay active)
   - platform: ble_client
+    type: characteristic
     ble_client_id: ensto1
     id: ensto1_real_time_indication_characteristic
     internal: true
@@ -209,6 +210,7 @@ sensor:
 
 # Adaptive temperature control status
   - platform: ble_client
+    type: characteristic
     ble_client_id: ensto1
     id: ensto1_adaptive_temp_control_characteristic
     internal: true
@@ -231,6 +233,7 @@ sensor:
 
 # Temperature calibration
   - platform: ble_client
+    type: characteristic
     ble_client_id: ensto1
     id: ensto1_temp_calibration_characteristic
     internal: true
@@ -260,6 +263,7 @@ sensor:
 
 # Temperature boost
   - platform: ble_client
+    type: characteristic
     ble_client_id: ensto1
     id: ensto1_boost_characteristic
     internal: true
@@ -305,6 +309,7 @@ sensor:
 
 # Power consumption
   - platform: ble_client
+    type: characteristic
     ble_client_id: ensto1
     id: ensto1_power_consumption_characteristic
     internal: true
@@ -372,6 +377,7 @@ sensor:
 
 # Max heating power (set manually from App)
   - platform: ble_client
+    type: characteristic
     ble_client_id: ensto1
     id: ensto1_heating_power_characteristic
     internal: true
@@ -394,6 +400,7 @@ sensor:
 
 # LED brightness
   - platform: ble_client
+    type: characteristic
     ble_client_id: ensto1
     id: ensto1_led_brightness_characteristic
     internal: true
@@ -429,6 +436,7 @@ sensor:
 
 # Energy unit price (set manually from App)
   - platform: ble_client
+    type: characteristic
     ble_client_id: ensto1
     id: ensto1_energy_unit_characteristic
     internal: true
@@ -461,6 +469,7 @@ sensor:
 
 # Factory reset ID
   - platform: ble_client
+    type: characteristic
     ble_client_id: ensto1
     id: ensto1_security_key_characteristic
     internal: true
@@ -759,9 +768,9 @@ climate:
     sensor: external_temperature_sensor
     preset:
       - name: home  # default
-        default_target_temperature_low: 20°C
+        default_target_temperature_low: 20.0°C
         mode: heat
-    default_target_temperature_low: 20°C # to be deprecated
+#    default_target_temperature_low: 20°C # to be deprecated
     heat_overrun: 0.5°C      # used in state machine above
     min_idle_time: 5s        # not really used, required field
     min_heating_off_time: 5s # not really used, required field


### PR DESCRIPTION
I´ve included  "type: characteristic" to ble_client sensors, as it seems to be required attribute since esphome 2022.10.0 release: _"Due to adding a new RSSI sensor to the ble_client sensor platform, a new type configuration variable. You will get a validation error when you try to install and you have not added a type to your existing configurations._"

Also I noticed error with validation via esphome if default_target_temperature_low was without the decimal, so I've included this as well. 

And as a last change I've included # to beginning of line "default_target_temperature_low: 20°C # to be deprecated", so that this is ignored during validation. Not sure if it is still needed or not, but validation was giving errors for me prior to this change. 

I've succesfully done these changes locally with my own esphome and ensto thermostat and at least it seems that it's working fine.